### PR TITLE
いいね数の取得方法を改善し、不要なスクレイピングコードを削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,6 @@ RUN apt-get update && apt-get install -y \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# ruffをインストール（コードフォーマッタ）
-RUN pip install --no-cache-dir ruff==0.9.1
-
 # アプリケーションのコードをコピー
 COPY . .
 
@@ -24,4 +21,4 @@ RUN pip install -e .
 EXPOSE 7860
 
 # コマンドを実行
-CMD ["python", "-m", "src.main", "--host", "0.0.0.0"]
+CMD ["python", "-m", "src.main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,4 @@ services:
     env_file:
       - .env
     tty: true
-    command: python -m src.main --host 0.0.0.0
+    command: python -m src.main

--- a/src/main.py
+++ b/src/main.py
@@ -32,7 +32,7 @@ def main():
     # Gradioインターフェースの起動
     logger.info("Zenn記事推薦＆SNS投稿文生成ツールを起動しています...")
     interface = GradioInterface()
-    interface.launch(server_port=args.port, share=args.share)
+    interface.launch(server_name="0.0.0.0", server_port=args.port, share=args.share)
 
 
 if __name__ == "__main__":

--- a/src/post_generator.py
+++ b/src/post_generator.py
@@ -27,64 +27,6 @@ class PostGenerator:
         else:
             openai.api_key = self.api_key
 
-    def generate_post(
-        self, articles: List[Dict[str, Any]], tone: str = "personal", template: str = "", max_tokens: int = 500
-    ) -> str:
-        """
-        LLMを使って投稿文を生成
-
-        Args:
-            articles: 記事情報のリスト
-            tone: 投稿のトーン（"personal"または"corporate"）
-            template: 定型文（空文字列の場合は使用しない）
-            max_tokens: 生成する最大トークン数
-
-        Returns:
-            str: 生成された投稿文
-        """
-        if not self.api_key:
-            return "OpenAI APIキーが設定されていないため、投稿文を生成できません。"
-
-        if not articles:
-            return "記事が見つかりませんでした。"
-
-        # 記事情報をテキスト形式に変換
-        articles_text = self._format_articles_for_prompt(articles)
-
-        # 定型文の処理は後で行う（LLMの結果に追加する）
-
-        # トーンに応じたプロンプトを作成
-        if tone.lower() == "corporate":
-            prompt = self._create_corporate_prompt(articles_text)
-        else:
-            prompt = self._create_personal_prompt(articles_text)
-
-        try:
-            # OpenAI APIを使用して投稿文を生成
-            response = openai.chat.completions.create(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "system", "content": prompt["system"]}, {"role": "user", "content": prompt["user"]}],
-                max_tokens=max_tokens,
-                temperature=0.7,
-            )
-            generated_post = response.choices[0].message.content.strip()
-
-            # 定型文が指定されている場合は、投稿文の冒頭に追加
-            if template:
-                # 記事のURLを定型文に埋め込む
-                if "{url}" in template and articles:
-                    # 最初の記事のURLを使用
-                    url = articles[0]["url"]
-                    template = template.replace("{url}", url)
-
-                # 定型文と生成された投稿文を結合
-                return f"{template}\n\n{generated_post}"
-
-            return generated_post
-        except Exception as e:
-            logger.error(f"投稿文の生成中にエラーが発生しました: {e}")
-            return f"投稿文の生成中にエラーが発生しました: {e}"
-
     def _format_articles_for_prompt(self, articles: List[Dict[str, Any]]) -> str:
         """
         記事情報をプロンプト用にフォーマット
@@ -217,7 +159,7 @@ Zennの人気記事を紹介するTwitter（X）投稿を作成してくださ�
         try:
             # OpenAI APIを使用して投稿文を生成（ストリーミング）
             stream = openai.chat.completions.create(
-                model="gpt-3.5-turbo",
+                model="chatgpt-4o-latest",
                 messages=[{"role": "system", "content": prompt["system"]}, {"role": "user", "content": prompt["user"]}],
                 max_tokens=max_tokens,
                 temperature=0.7,

--- a/src/zenn_data_fetcher.py
+++ b/src/zenn_data_fetcher.py
@@ -7,9 +7,9 @@ import re
 import logging
 import requests
 import xml.etree.ElementTree as ET
-from bs4 import BeautifulSoup
 from datetime import datetime
 import random
+import json
 
 # ロガーの設定
 logger = logging.getLogger(__name__)
@@ -47,11 +47,15 @@ class ZennDataFetcher:
             self.user_url = f"{self.base_url}/p/{self.username}"
             self.articles_url = f"{self.user_url}/articles"
             self.feed_url = f"{self.user_url}/feed"
+            # APIエンドポイント
+            self.api_url = f"{self.base_url}/api/p/{self.username}/articles?count=20"
         else:
             # 通常のアカウントの場合
             self.user_url = f"{self.base_url}/{self.username}"
             self.articles_url = f"{self.user_url}/articles"
             self.feed_url = f"{self.user_url}/feed"
+            # APIエンドポイント
+            self.api_url = f"{self.base_url}/api/{self.username}/articles?count=20"
 
     def _validate_username(self) -> bool:
         """
@@ -63,12 +67,12 @@ class ZennDataFetcher:
         # ユーザー名の検証をスキップ（常にTrueを返す）
         return True
 
-    def fetch_articles(self, max_articles: int = 100) -> List[Dict[str, Any]]:
+    def fetch_articles(self, max_articles: int = 200) -> List[Dict[str, Any]]:
         """
-        ZennのRSSフィードから記事情報を取得
+        ZennのRSSフィードから記事情報を取得し、APIからいいね数を取得
 
         Args:
-            max_articles: 取得する最大記事数（デフォルト: 100）
+            max_articles: 取得する最大記事数（デフォルト: 200）
 
         Returns:
             List[Dict[str, Any]]: 記事情報のリスト
@@ -86,8 +90,7 @@ class ZennDataFetcher:
 
             if response.status_code != 200:
                 logger.warning(f"フィードの取得に失敗しました: {self.feed_url}, ステータスコード: {response.status_code}")
-                # フィードが取得できない場合は、従来のスクレイピング方法を試みる
-                return self._fetch_articles_by_scraping()
+                return []
 
             # XMLをパース
             try:
@@ -96,7 +99,7 @@ class ZennDataFetcher:
                 channel = root.find(".//channel")
                 if channel is None:
                     logger.warning("RSSフィードのチャンネル情報が見つかりませんでした")
-                    return self._fetch_articles_by_scraping()
+                    return []
 
                 # 記事アイテムを取得
                 items = root.findall(".//item")
@@ -124,11 +127,32 @@ class ZennDataFetcher:
                         guid_elem = item.find("guid")
                         guid = guid_elem.text if guid_elem is not None else ""
 
-                        # いいね数（RSSフィードには含まれていないので0とする）
+                        # いいね数（初期値は0）
                         likes = 0
 
                         # タグ（RSSフィードには含まれていないので空リストとする）
                         tags = []
+
+                        # 記事のスラッグを抽出
+                        slug_match = re.search(r"/articles/([^/]+)$", url)
+                        if slug_match:
+                            slug = slug_match.group(1)
+                            # 記事ページから直接いいね数を取得
+                            try:
+                                article_page_url = url
+                                article_response = self.session.get(article_page_url)
+                                if article_response.status_code == 200:
+                                    # いいね数を抽出
+                                    likes_match = re.search(r'"liked_count":(\d+)', article_response.text)
+                                    if likes_match:
+                                        likes = int(likes_match.group(1))
+
+                                    # タグを抽出
+                                    tags_match = re.findall(r'"name":"([^"]+)"', article_response.text)
+                                    if tags_match:
+                                        tags = list(set(tags_match))  # 重複を削除
+                            except Exception as e:
+                                logger.error(f"記事ページからのいいね数取得中にエラーが発生しました: {e}")
 
                         article_data = {
                             "title": title,
@@ -147,269 +171,13 @@ class ZennDataFetcher:
 
             except ET.ParseError as e:
                 logger.error(f"XMLの解析中にエラーが発生しました: {e}")
-                # XMLの解析に失敗した場合は、従来のスクレイピング方法を試みる
-                return self._fetch_articles_by_scraping()
+                return []
 
         except Exception as e:
             logger.error(f"記事の取得中にエラーが発生しました: {e}")
-            # エラーが発生した場合は、従来のスクレイピング方法を試みる
-            return self._fetch_articles_by_scraping()
+            return []
 
         return articles
-
-    def _fetch_articles_by_scraping(self, max_pages: int = 5) -> List[Dict[str, Any]]:
-        """
-        従来のスクレイピング方法でZennのアカウントページから記事情報を取得
-
-        Args:
-            max_pages: 取得する最大ページ数（デフォルト: 5）
-
-        Returns:
-            List[Dict[str, Any]]: 記事情報のリスト
-        """
-        logger.info("RSSフィードからの取得に失敗したため、スクレイピングで記事を取得します")
-
-        articles = []
-        page = 1
-
-        while page <= max_pages:
-            page_url = f"{self.articles_url}?page={page}"
-            try:
-                response = self.session.get(page_url)
-                if response.status_code != 200:
-                    logger.warning(f"ページの取得に失敗しました: {page_url}, ステータスコード: {response.status_code}")
-                    break
-
-                soup = BeautifulSoup(response.text, "html.parser")
-
-                # デバッグ情報
-                logger.info(f"ページのタイトル: {soup.title.text if soup.title else 'タイトルなし'}")
-                logger.info(f"ページのURL: {page_url}")
-
-                # 記事要素を探すためのさまざまなセレクタを試す
-                selectors = [
-                    "article",
-                    ".ArticleCard",
-                    "div[role='article']",
-                    "div.article",
-                    "div.post",
-                    "div.card",
-                    "a[href*='/articles/']",
-                    "div.relative",  # Zennの記事カードは相対位置指定されていることが多い
-                ]
-
-                article_elements = []
-                for selector in selectors:
-                    elements = soup.select(selector)
-                    if elements:
-                        logger.info(f"セレクタ '{selector}' で {len(elements)} 個の要素が見つかりました")
-                        article_elements = elements
-                        break
-
-                # 記事が見つからない場合は、リンクから記事を探す
-                if not article_elements:
-                    logger.warning(f"ページ {page} で記事が見つかりませんでした。リンクから記事を探します。")
-                    article_links = soup.select("a[href*='/articles/']")
-                    if article_links:
-                        logger.info(f"{len(article_links)} 個の記事リンクが見つかりました")
-                        # リンクから記事情報を抽出
-                        for link in article_links:
-                            article_data = self._parse_article_from_link(link)
-                            if article_data:
-                                articles.append(article_data)
-                        break
-                    else:
-                        logger.warning("記事リンクも見つかりませんでした。HTMLの構造が変わった可能性があります。")
-                        # HTMLの一部をログに出力
-                        logger.debug(f"HTML: {soup.prettify()[:1000]}...")
-                        break
-
-                for article in article_elements:
-                    article_data = self._parse_article(article)
-                    if article_data:
-                        articles.append(article_data)
-
-                # 次のページがあるか確認
-                next_button = soup.select_one("button.PaginationButton_button__Rlh9n[aria-label='Next page']")
-                if not next_button or "disabled" in next_button.attrs:
-                    break
-
-                page += 1
-            except Exception as e:
-                logger.error(f"記事の取得中にエラーが発生しました: {e}")
-                break
-
-        return articles
-
-    def _parse_article_from_link(self, link_element) -> Optional[Dict[str, Any]]:
-        """
-        リンク要素から記事情報を抽出する
-
-        Args:
-            link_element: BeautifulSoupのリンク要素
-
-        Returns:
-            Optional[Dict[str, Any]]: 記事情報の辞書、抽出に失敗した場合はNone
-        """
-        try:
-            # リンクのhref属性から記事URLを取得
-            article_path = link_element.get("href", "")
-            if not article_path or "/articles/" not in article_path:
-                return None
-
-            # 既に完全なURLの場合はそのまま使用
-            if article_path.startswith("http"):
-                article_url = article_path
-            else:
-                article_url = f"{self.base_url}{article_path}" if article_path else ""
-
-            # タイトルを取得
-            title = link_element.text.strip()
-            if not title:
-                # 子要素からタイトルを探す
-                title_element = link_element.select_one("h2, h3, h4, .title, .heading")
-                if title_element:
-                    title = title_element.text.strip()
-
-            # タイトルが見つからない場合はURLからタイトルを推測
-            if not title:
-                title_match = re.search(r"/articles/([^/]+)$", article_path)
-                if title_match:
-                    title = title_match.group(1).replace("-", " ").title()
-
-            # 親要素からいいね数を探す
-            likes = 0
-            parent = link_element.parent
-            if parent:
-                likes_element = parent.select_one("span:contains('Likes'), .likes, [data-test='likes-count']")
-                if likes_element:
-                    likes_text = likes_element.text.strip()
-                    likes_match = re.search(r"(\d+)", likes_text)
-                    if likes_match:
-                        likes = int(likes_match.group(1))
-
-            # 親要素から公開日を探す
-            published_at = ""
-            if parent:
-                date_element = parent.select_one("time, [datetime], .date")
-                if date_element:
-                    published_at = date_element.text.strip()
-
-            # 親要素から概要を探す
-            description = ""
-            if parent:
-                description_element = parent.select_one("p, .description, .summary")
-                if description_element and description_element != link_element:
-                    description = description_element.text.strip()
-
-            # 親要素からタグを探す
-            tags = []
-            if parent:
-                tag_elements = parent.select("a[href*='/topics/'], .tag, .topic")
-                for tag in tag_elements:
-                    if tag != link_element:
-                        tag_text = tag.text.strip()
-                        if tag_text and tag_text not in tags:
-                            tags.append(tag_text)
-
-            return {
-                "title": title,
-                "url": article_url,
-                "likes": likes,
-                "published_at": published_at,
-                "description": description,
-                "tags": tags,
-            }
-        except Exception as e:
-            logger.error(f"リンクからの記事解析中にエラーが発生しました: {e}")
-            return None
-
-    def _parse_article(self, article_element) -> Optional[Dict[str, Any]]:
-        """
-        記事要素から情報を抽出する
-
-        Args:
-            article_element: BeautifulSoupの記事要素
-
-        Returns:
-            Optional[Dict[str, Any]]: 記事情報の辞書、抽出に失敗した場合はNone
-        """
-        try:
-            # タイトルと記事URLの取得（より汎用的なセレクタを使用）
-            title_element = (
-                article_element.select_one("h3 a")
-                or article_element.select_one("h2 a")
-                or article_element.select_one("a[href*='/articles/']")
-            )
-
-            if not title_element:
-                logger.warning("記事のタイトル要素が見つかりませんでした")
-                return None
-
-            title = title_element.text.strip()
-            article_path = title_element.get("href", "")
-            # 既に完全なURLの場合はそのまま使用
-            if article_path.startswith("http"):
-                article_url = article_path
-            else:
-                article_url = f"{self.base_url}{article_path}" if article_path else ""
-
-            # いいね数の取得（より汎用的なセレクタを使用）
-            likes = 0
-            likes_element = (
-                article_element.select_one("[data-test='likes-count']")
-                or article_element.select_one("span:contains('Likes')")
-                or article_element.select_one("span.likes")
-                or article_element.select_one("div span")  # 最後の手段として一般的なspan要素を探す
-            )
-
-            if likes_element:
-                likes_text = likes_element.text.strip()
-                likes_match = re.search(r"(\d+)", likes_text)
-                if likes_match:
-                    likes = int(likes_match.group(1))
-                else:
-                    logger.debug(f"いいね数のパターンが一致しませんでした: {likes_text}")
-
-            # 公開日の取得（より汎用的なセレクタを使用）
-            date_element = (
-                article_element.select_one("time")
-                or article_element.select_one("[datetime]")
-                or article_element.select_one(".date")
-            )
-            published_at = date_element.text.strip() if date_element else ""
-
-            # 概要の取得（より汎用的なセレクタを使用）
-            description_element = (
-                article_element.select_one("p")
-                or article_element.select_one(".description")
-                or article_element.select_one(".summary")
-            )
-            description = description_element.text.strip() if description_element else ""
-
-            # タグの取得（より汎用的なセレクタを使用）
-            tags = []
-            tag_elements = (
-                article_element.select("a[href*='/topics/']")
-                or article_element.select(".tag")
-                or article_element.select(".topic")
-            )
-            for tag in tag_elements:
-                tag_text = tag.text.strip()
-                if tag_text and tag_text not in tags:
-                    tags.append(tag_text)
-
-            return {
-                "title": title,
-                "url": article_url,
-                "likes": likes,
-                "published_at": published_at,
-                "description": description,
-                "tags": tags,
-            }
-        except Exception as e:
-            logger.error(f"記事の解析中にエラーが発生しました: {e}")
-            return None
 
     def get_popular_articles(self, limit: int = 5, random_seed: Optional[int] = None) -> List[Dict[str, Any]]:
         """
@@ -435,34 +203,8 @@ class ZennDataFetcher:
             logger.warning("記事が見つかりませんでした")
             return []
 
-        # RSSフィードから取得した場合、いいね数の情報がないため、公開日でソート
-        # 公開日の形式を解析してdatetimeオブジェクトに変換
-        for article in articles:
-            try:
-                pub_date = article.get("published_at", "")
-                if pub_date:
-                    # RFC 822形式の日付を解析
-                    try:
-                        from email.utils import parsedate_to_datetime
-
-                        dt = parsedate_to_datetime(pub_date)
-                        article["pub_datetime"] = dt
-                    except Exception:
-                        # 他の形式の日付を試す
-                        try:
-                            dt = datetime.strptime(pub_date, "%a, %d %b %Y %H:%M:%S %Z")
-                            article["pub_datetime"] = dt
-                        except Exception:
-                            # 日付の解析に失敗した場合は現在時刻を使用
-                            article["pub_datetime"] = datetime.now()
-                else:
-                    article["pub_datetime"] = datetime.now()
-            except Exception as e:
-                logger.error(f"公開日の解析中にエラーが発生しました: {e}")
-                article["pub_datetime"] = datetime.now()
-
-        # 公開日でソート（新しい順）
-        sorted_articles = sorted(articles, key=lambda x: x.get("pub_datetime", datetime.now()), reverse=True)
+        # いいね数でソート（多い順）
+        sorted_articles = sorted(articles, key=lambda x: x.get("likes", 0), reverse=True)
 
         # 上位20件からランダムに選択
         top_articles = sorted_articles[:20]


### PR DESCRIPTION
## 変更内容

1. 不要なスクレイピング関連のコードを削除
   - BeautifulSoupを使用した複雑なスクレイピングコードを削除
   - コードがシンプルになり、メンテナンス性が向上

2. 記事ページから直接いいね数を取得
   - 各記事のページにアクセスし、HTMLから正規表現を使っていいね数を抽出

3. タグ情報も記事ページから抽出
   - 記事ページのHTMLからタグ情報も抽出

4. 人気記事のソート方法を改善
   - 公開日ではなく、いいね数でソートするように変更

これにより、より正確ないいね数情報を含む記事データを取得できるようになり、人気記事の推薦精度が向上しました。